### PR TITLE
Added sign-in/sign-up modal

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -8,6 +8,7 @@ const getFormFields = require('../../../lib/get-form-fields.js')
 const onSignUp = function (event) {
   event.preventDefault()
   const data = getFormFields(event.target)
+  console.log('You have arrived at onSignUp in auth/events.js')
   api.post(data)
     .then(ui.onAddUserSuccess)
     .catch(ui.onAddUserFailure)

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -16,3 +16,21 @@ $(() => {
 
 // use require without a reference to ensure a file is bundled
 require('./example')
+
+// optional JS for bootstrap modal for signup/sign in
+$(function () {
+  $('#login-form-link').click(function (e) {
+    $('#sign-in').delay(100).fadeIn(100)
+    $('#sign-up').fadeOut(100)
+    $('#register-form-link').removeClass('active')
+    $(this).addClass('active')
+    e.preventDefault()
+  })
+  $('#register-form-link').click(function (e) {
+    $('#sign-up').delay(100).fadeIn(100)
+    $('#sign-in').fadeOut(100)
+    $('#login-form-link').removeClass('active')
+    $(this).addClass('active')
+    e.preventDefault()
+  })
+})

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,2 +1,125 @@
 $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 @import '~bootstrap-sass/assets/stylesheets/bootstrap';
+
+
+#regContainer{
+    margin-top: 3%;
+}
+
+.panel-login {
+    border-color: #ccc;
+     background-color: #f9f8f8;
+    -webkit-box-shadow: 0px 2px 3px 0px rgba(0,0,0,0.2);
+    -moz-box-shadow: 0px 2px 3px 0px rgba(0,0,0,0.2);
+    box-shadow: 0px 2px 3px 0px rgba(0,0,0,0.2);
+}
+.panel-login>.panel-heading {
+    text-align:center;
+}
+.panel-login>.panel-heading a{
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 28px;
+    -webkit-transition: all 0.1s linear;
+    -moz-transition: all 0.1s linear;
+    transition: all 0.1s linear;
+}
+.panel-login>.panel-heading a.active{
+    font-size: 34px;
+}
+.panel-login>.panel-heading hr{
+    margin-top: 10px;
+    margin-bottom: 0px;
+    clear: both;
+    border: 0;
+    height: 1px;
+    background-image: -webkit-linear-gradient(left,rgba(0, 0, 0, 0),rgba(0, 0, 0, 0.15),rgba(0, 0, 0, 0));
+    background-image: -moz-linear-gradient(left,rgba(0,0,0,0),rgba(0,0,0,0.15),rgba(0,0,0,0));
+    background-image: -ms-linear-gradient(left,rgba(0,0,0,0),rgba(0,0,0,0.15),rgba(0,0,0,0));
+    background-image: -o-linear-gradient(left,rgba(0,0,0,0),rgba(0,0,0,0.15),rgba(0,0,0,0));
+}
+.panel-login input[type="text"],.panel-login input[type="email"],.panel-login input[type="password"] {
+    height: 45px;
+    border: 1px solid #ddd;
+    font-size: 16px;
+    -webkit-transition: all 0.1s linear;
+    -moz-transition: all 0.1s linear;
+    transition: all 0.1s linear;
+}
+.panel-login input:hover,
+.panel-login input:focus {
+    outline:none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+    border-color: #ccc;
+}
+.btn-login {
+    background-color:#3D9DB3;
+    outline: none;
+    color: #fff;
+    font-size: 14px;
+    height: auto;
+    font-weight: normal;
+    padding: 14px 0;
+    text-transform: uppercase;
+    border-color: #2d92a9;
+}
+.btn-login:hover,
+.btn-login:focus {
+    color: #fff;
+    background-color: #198da8;
+    border-color: #53A3CD;
+}
+.btn-register {
+    background-color: #17ae47;
+    outline: none;
+    color: #fff;
+    font-size: 14px;
+    height: auto;
+    font-weight: normal;
+    padding: 14px 0;
+    text-transform: uppercase;
+    border-color: #1CB94A;
+}
+.btn-register:hover,
+.btn-register:focus {
+    color: #fff;
+    background-color: #1CA347;
+    border-color: #1CA347;
+}
+
+.fullscreen_bg {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-size: cover;
+    background-position: 50% 50%;
+    // background-image: url('https://jointgroup.es/wp-content/uploads/2016/11/joint-network-group.jpg');
+      // background-image: url('https://media.giphy.com/media/PFHeqlty75OLe/giphy.gif');
+      background-image: url('https://static1.squarespace.com/static/5457dddee4b0a2f014f36614/t/567d41e4a976af5d460a07df/1451049452980/?format=1000w');
+    background-repeat:repeat;
+  }
+
+.panel-heading a{
+    font-size: 48px;
+    color: rgb(6, 106, 117);
+    padding: 2px 0 10px 0;
+    font-family: 'FranchiseRegular','Arial Narrow',Arial,sans-serif;
+    font-weight: bold;
+    text-align: center;
+    padding-bottom: 30px;
+}
+
+.panel-heading a{
+    background: -webkit-repeating-linear-gradient(-45deg,
+    rgb(18, 83, 93) ,
+    rgb(18, 83, 93) 20px,
+    rgb(64, 111, 118) 20px,
+    rgb(64, 111, 118) 40px,
+    rgb(18, 83, 93) 40px);
+    -webkit-text-fill-color: transparent;
+    -webkit-background-clip: text;
+}

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-      <title>AutoMom</title>
+      <title>Gesso</title>
       <meta name="viewport" content="width=device-width, initial-scale=1">
 
       <!-- Do not add `link` tags unless you know what you are doing -->
@@ -27,8 +27,82 @@
    </div> -->
  </div>
 
+<!-- Beginning of modal login experiment -->
+<div id="fullscreen_bg" class="fullscreen_bg"/>
+<div id="regContainer" class="container">
+      <div class="row">
+      <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-login">
+          <div class="panel-heading">
+            <div class="row">
+              <div class="col-xs-6">
+                <a href="#" class="active" id="login-form-link">Login</a>
+              </div>
+              <div class="col-xs-6">
+                <a href="#" id="register-form-link">Register</a>
+              </div>
+            </div>
+            <hr>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-lg-12">
+                <!-- Note below is the #sign-up that corresponds to the event handler in auth/events.js -->
+                <form id="sign-in" action="#" method="post" role="form" style="display: block;">
+                  <div class="form-group">
+                    <label for="username">Email</label>
+                    <input type="text" name="credentials[email]" id="username" tabindex="1" class="form-control" placeholder="Username" value="">
+                  </div>
+                  <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" name="credentials[password]" id="password" tabindex="2" class="form-control" placeholder="Password">
+                  </div>
+                  <div class="form-group text-center">
+                    <input type="checkbox" tabindex="3" class="" name="remember" id="remember">
+                    <label for="remember"> Remember Me</label>
+                  </div>
+                  <div class="form-group">
+                    <div class="row">
+                      <div class="col-sm-6 col-sm-offset-3">
+                        <input type="submit" name="submit" id="login-submit" tabindex="4" class="form-control btn btn-login" value="Log In">
+                      </div>
+                    </div>
+                  </div>
+                </form>
+                <form id="sign-up" action="#" method="post" role="form" style="display: none;">
+                  <div class="form-group">
+                    <label for="Email">Email</label>
+                    <input type="text" name="credentials[email]" id="email" tabindex="1" class="form-control" placeholder="Email" value="">
+                  </div>
+                  <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" name="credentials[password]" id="password" tabindex="2" class="form-control" placeholder="Password">
+                  </div>
+                  <div class="form-group">
+                    <label for="confirm-password">Confirm password</label>
+                    <input type="password" name="credentials[password_confirmation]" id="confirm-password" tabindex="2" class="form-control" placeholder="Confirm Password">
+                  </div>
+                  <div class="form-group">
+                    <div class="row">
+                      <div class="col-sm-6 col-sm-offset-3">
+                        <input type="submit" name="submit" id="register-submit" tabindex="4" class="form-control btn btn-register" value="Register Now">
+                      </div>
+                    </div>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<!-- End of modal login experiment -->
+
+
    <div class="container">
-   <div class="row">
+   <!-- <div class="row">
      <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
        <div id="sign-up-wrapper">
        <div class="thumbnail">
@@ -66,7 +140,7 @@
          </div>
        </div>
      </div>
-     </div>
+     </div> -->
 
      <div id ="sign-out-wrapper" class="hidden">
      <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">


### PR DESCRIPTION
Added sign-in/sign-up modal adapting code from:
https://bootsnipp.com/snippets/jvamD

Bootstrap-specific js was added to /scripts/index.js;
this handles the transition between the modal's states (one
for sign in, one for sign-up).

Signing up via modal returns 201 Created from API, as expected.
Signing in via modal returns 200 OK from API, as expected.

Added background gif for visual interest.

Modified index.scss for modal styling

Modified events.js for logging/testing purposes.

Next steps are to hook up the code in auth/ui.js so that logging in
hides sign-up/sign-in modal and displays CRUD divs to user.

Closes issue #8.