### PR TITLE
Hides CRUD features upon successful logout

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -66,7 +66,7 @@ const signOutSuccess = () => {
   // targets div chore-list, which is in index.html
   $('#chore-list').empty()
   store.user = null
-  $('#chore-crud').addClass('hidden')
+  $('#show-crud').addClass('hidden')
   // this restores the show chore button so it shows when the next user logs in.
   //   $('#show-chore-button').hide() is used in chores/ui.js
   // in the showChoreSuccess function. It hides the button so users
@@ -76,10 +76,10 @@ const signOutSuccess = () => {
 
   // Update: have moved the chore-crud div down so that it does not enclose the
   // show chore feature. Temporarily shows. Can fix later.
-  $('#show-chore-button').show()
-  $('#show-chores-wrapper').addClass('hidden')
+  // $('#show-chore-button').show()
+  $('#show-listing-wrapper').addClass('hidden')
   $('#sign-out-wrapper').addClass('hidden')
-  $('#sign-up-wrapper').removeClass('hidden')
+  $('#regContainer').removeClass('hidden')
   $('#sign-in-wrapper').removeClass('hidden')
   $('#usermessages').text('You are signed out. Thanks for visiting! Text your mama :)')
 }


### PR DESCRIPTION
Modified /auth/ui.js signOutSuccess() function to
add class 'hidden' to #show-crud div and #show-listing-wrapper div.

This successfully hides CRUD features/forms upon logout.

There are still many divs/jQuery lines referring to previous project
that will have to be added to issues for later cleanup.

Closes Issue #15.