### PR TITLE
Changed text of signout button & removed extra label

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
           </li>
           <li>      <form id="sign-out">
                <!-- Change password form fields  need to be changed to meet API and event-handler requirements -->
-              <input type="submit" name="submit" class="btn btn-success">Sign out</input>
+              <input type="submit" name="submit" class="btn btn-success" value="Sign Out"></input>
             </form>
             <!-- <a class="btn btn-default btn-outline btn-circle" data-toggle="collapse" href="#nav-collapse2" aria-expanded="false" aria-controls="nav-collapse3">Sign out</a> -->
           </li>


### PR DESCRIPTION
Solved by adding a value="Sign Out" property to the button.

Modified button works to log a user out and returns `204 No Content`
from the API as expected.

Closes Issue #44.